### PR TITLE
writeLines->write_lines for mac/pc compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Depends:
 Imports:
   dplyr,
   methods,
+  readr,
   remake,
   storr,
   tidyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.5
-Date: 2018-2-7
+Version: 0.0.6
+Date: 2018-5-3
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"))
 Description: Functions to organize a data analysis repository and ensure that data flows smoothly.

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -15,7 +15,7 @@ gd_config <- function(folder, config_file=getOption("scipiper.gd_config_file")) 
   # write the given information to the specified config_file
   cfg <- list(folder=folder)
   if(!dir.exists(dirname(config_file))) dir.create(dirname(config_file), recursive=TRUE)
-  writeLines(yaml::as.yaml(cfg), config_file)
+  readr::write_lines(yaml::as.yaml(cfg), config_file)
   
   # check for credentials
   cred_file <- '.httr-oauth'

--- a/R/s3.R
+++ b/R/s3.R
@@ -16,7 +16,7 @@ s3_config <- function(bucket, profile='default', config_file=getOption("scipiper
   # write the given information to the specified config_file
   cfg <- list(bucket=bucket, profile=profile)
   if(!dir.exists(dirname(config_file))) dir.create(dirname(config_file), recursive=TRUE)
-  writeLines(yaml::as.yaml(cfg), config_file)
+  readr::write_lines(yaml::as.yaml(cfg), config_file)
   
   # check for credentials
   cred_file <- aws.signature::default_credentials_file()

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -139,7 +139,7 @@ sc_indicate <- function(ind_file, ..., data_file) {
   }
   
   # write the info to the indicator file
-  writeLines(yaml::as.yaml(info_list), con=ind_file)
+  readr::write_lines(yaml::as.yaml(info_list), con=ind_file)
   
   invisible(NULL)
 }
@@ -313,7 +313,7 @@ YAMLify_build_status <- function(target_names, remake_file=getOption('scipiper.r
     status_yml <- yaml::as.yaml(status)
     status_key <- get_mangled_key(to_export[i], dbstore)
     status_file <- file.path('build/status', paste0(status_key, '.yml'))
-    writeLines(status_yml, status_file)
+    readr::write_lines(status_yml, status_file)
     
     return(status_file)
   })

--- a/inst/extdata/sharedcache/demo.R
+++ b/inst/extdata/sharedcache/demo.R
@@ -44,7 +44,7 @@ get_hash <- function(fname) {
 # make_file must be defined in both helper-demo.R and extdata/sharedcache/demo.R
 # because we need it both places, remake only sees one
 make_file <- function(fname, ftext='', ftstamp=Sys.time()) { # "2017-09-05 07:00:00 MST"
-  writeLines(ftext, con=fname)
+  readr::write_lines(ftext, con=fname)
   system(sprintf('touch -d "%s" %s', POSIX2char(ftstamp), fname))
   invisible(NULL)
 }

--- a/tests/testthat/helper-demo.R
+++ b/tests/testthat/helper-demo.R
@@ -1,7 +1,7 @@
 # make_file must be defined in both helper-demo.R and extdata/sharedcache/demo.R
 # because we need it both places, remake only sees one
 make_file <- function(fname, ftext='', ftstamp=Sys.time()) { # "2017-09-05 07:00:00 MST"
-  writeLines(ftext, con=fname)
+  readr::write_lines(ftext, con=fname)
   system(sprintf('touch -d "%s" %s', POSIX2char(ftstamp), fname))
   invisible(NULL)
 }

--- a/tests/testthat/test-shared_cache.R
+++ b/tests/testthat/test-shared_cache.R
@@ -407,7 +407,7 @@ test_that("d7", {
   # pull once, delete A.cache (corrupt cache), edit R
   di <- setup_demo('B.rds')
   on.exit(cleanup_demo(di))
-  writeLines('A2', 'A.txt.cache')
+  readr::write_lines('A2', 'A.txt.cache')
   develop_local_R3(di)
   expect_equal(unname(inspect_local(di)), c('A2','[A1]','---','3','A1B1','[A1B1]','---'))
   expect_error(capture_make('B.rds'), "despite A.txt.ind, badhash A.txt.cache")


### PR DESCRIPTION
we've been discovering that because of different line endings, hashes of the .ind and config.yml files aren't the same when coming from pc or mac. readr::write_lines uses consistent line endings whereas writeLines didn't.