### PR TITLE
change default RDSify_build_status to new_only=FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.8
-Date: 2018-06-07
+Version: 0.0.9
+Date: 2018-07-12
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"))
 Description: Functions to organize a data analysis repository and ensure that data flows smoothly.

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -430,16 +430,18 @@ YAMLify_build_status <- function(target_names, remake_file=getOption('scipiper.r
 #'
 #' Copy build status files from versionable text to .remake binary (.rds file)
 #'
-#' @param new_only logical. You could corrupt a shared-cache repo by calling
+#' @param new_only logical. It's possible to corrupt a shared-cache repo. One
+#'   way this happens seems to be something about collaborating on .ind and
+#'   build/status files via git. Another way to corrupt it is by calling
 #'   remake::make after git pulling new build/status files and before calling
-#'   scmake. Therefore, (1) you should avoid calling remake::make in a
-#'   shared-cache repo; call scmake instead, and (2) this flag provides
-#'   recourse; set new_only=FALSE to overwrite all .remake files for which we
-#'   have build/status files
+#'   scmake. Therefore, (1) this flag provides recourse; set new_only=FALSE to
+#'   overwrite all .remake files for which we have build/status files, (2) the
+#'   default is FALSE, and (3) still, you should avoid calling remake::make in a
+#'   shared-cache repo; call scmake instead.
 #' @param remake_file filename of the remake YAML file for which build/status
 #'   files should be RDSified
 #' @keywords internal
-RDSify_build_status <- function(new_only=TRUE, remake_file=getOption('scipiper.remake_file')) {
+RDSify_build_status <- function(new_only=FALSE, remake_file=getOption('scipiper.remake_file')) {
   # get info about the remake project. calling remake:::remake gives us info and
   # simultaneously ensures there's a directory to receive the export (creates
   # the .remake dir as a storr)

--- a/man/RDSify_build_status.Rd
+++ b/man/RDSify_build_status.Rd
@@ -4,16 +4,18 @@
 \alias{RDSify_build_status}
 \title{Copy info from build/status to .remake/objects}
 \usage{
-RDSify_build_status(new_only = TRUE,
+RDSify_build_status(new_only = FALSE,
   remake_file = getOption("scipiper.remake_file"))
 }
 \arguments{
-\item{new_only}{logical. You could corrupt a shared-cache repo by calling
+\item{new_only}{logical. It's possible to corrupt a shared-cache repo. One
+way this happens seems to be something about collaborating on .ind and
+build/status files via git. Another way to corrupt it is by calling
 remake::make after git pulling new build/status files and before calling
-scmake. Therefore, (1) you should avoid calling remake::make in a
-shared-cache repo; call scmake instead, and (2) this flag provides
-recourse; set new_only=FALSE to overwrite all .remake files for which we
-have build/status files}
+scmake. Therefore, (1) this flag provides recourse; set new_only=FALSE to
+overwrite all .remake files for which we have build/status files, (2) the
+default is FALSE, and (3) still, you should avoid calling remake::make in a
+shared-cache repo; call scmake instead.}
 
 \item{remake_file}{filename of the remake YAML file for which build/status
 files should be RDSified}


### PR DESCRIPTION
Trying to make vizstorm work better by reducing number of times we experience corrupt/outdated remake status information.