### PR TITLE
1-argument option for gd_put, s3_put

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.10
-Date: 2018-07-27
+Version: 0.0.11
+Date: 2018-08-02
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"))
 Description: Functions to organize a data analysis repository and ensure that data flows smoothly.

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -50,7 +50,9 @@ gd_config <- function(folder, config_file=getOption("scipiper.gd_config_file")) 
 #'   different targets and this function's local_source argument should match
 #'   the target of the 'a' recipe while this function's remote_ind argument
 #'   should match the target of this recipe (=='b') and the data_file target of
-#'   the 'c' recipe. See the examples.
+#'   the 'c' recipe. See the examples. Nonetheless, because we have commonly
+#'   adopted the 2-target option where remote_ind and local_source _can_ be the
+#'   same, the default for this argument is to set `local_source=remote_ind`.
 #' @param mock_get character. if remote_ind and local_source imply different
 #'   local file locations, should the current local file (implied by
 #'   local_source) be left alone ('none'), or copied ('copy') or moved ('move')
@@ -120,7 +122,7 @@ gd_config <- function(folder, config_file=getOption("scipiper.gd_config_file")) 
 #'
 #' }
 gd_put <- function(
-  remote_ind, local_source, mock_get=c('copy','move','none'),
+  remote_ind, local_source=remote_ind, mock_get=c('copy','move','none'),
   on_exists=c('update','replace','stop'), type=NULL, verbose=FALSE,
   dry_put=getOption("scipiper.dry_put"),
   config_file=getOption("scipiper.gd_config_file"),

--- a/R/s3.R
+++ b/R/s3.R
@@ -51,7 +51,9 @@ s3_config <- function(bucket, profile='default', config_file=getOption("scipiper
 #'   different targets and this function's local_source argument should match
 #'   the target of the 'a' recipe while this function's remote_ind argument
 #'   should match the target of this recipe (=='b') and the data_file target of
-#'   the 'c' recipe. See the examples.
+#'   the 'c' recipe. See the examples. Nonetheless, because we have commonly
+#'   adopted the 2-target option where remote_ind and local_source _can_ be the
+#'   same, the default for this argument is to set `local_source=remote_ind`.
 #' @param mock_get character. if remote_ind and local_source imply different
 #'   local file locations, should the current local file (implied by
 #'   local_source) be left alone ('none'), or copied ('copy') or moved ('move')
@@ -70,7 +72,7 @@ s3_config <- function(bucket, profile='default', config_file=getOption("scipiper
 #'   remote_ind
 #' @export
 s3_put <- function(
-  remote_ind, local_source,  mock_get=c('copy','move','none'),
+  remote_ind, local_source=remote_ind,  mock_get=c('copy','move','none'),
   on_exists=c('replace','stop'), verbose = FALSE,
   dry_put=getOption("scipiper.dry_put"),
   config_file=getOption("scipiper.s3_config_file"),

--- a/man/gd_put.Rd
+++ b/man/gd_put.Rd
@@ -4,8 +4,8 @@
 \alias{gd_put}
 \title{Upload a file to Google Drive}
 \usage{
-gd_put(remote_ind, local_source, mock_get = c("copy", "move", "none"),
-  on_exists = c("update", "replace", "stop"), type = NULL,
+gd_put(remote_ind, local_source = remote_ind, mock_get = c("copy", "move",
+  "none"), on_exists = c("update", "replace", "stop"), type = NULL,
   verbose = FALSE, dry_put = getOption("scipiper.dry_put"),
   config_file = getOption("scipiper.gd_config_file"),
   ind_ext = getOption("scipiper.ind_ext"))
@@ -28,7 +28,9 @@ data_file from google drive, then the 'a' and 'c' recipes must have
 different targets and this function's local_source argument should match
 the target of the 'a' recipe while this function's remote_ind argument
 should match the target of this recipe (=='b') and the data_file target of
-the 'c' recipe. See the examples.}
+the 'c' recipe. See the examples. Nonetheless, because we have commonly
+adopted the 2-target option where remote_ind and local_source \emph{can} be the
+same, the default for this argument is to set \code{local_source=remote_ind}.}
 
 \item{mock_get}{character. if remote_ind and local_source imply different
 local file locations, should the current local file (implied by

--- a/man/s3_put.Rd
+++ b/man/s3_put.Rd
@@ -4,8 +4,8 @@
 \alias{s3_put}
 \title{Upload a file to S3}
 \usage{
-s3_put(remote_ind, local_source, mock_get = c("copy", "move", "none"),
-  on_exists = c("replace", "stop"), verbose = FALSE,
+s3_put(remote_ind, local_source = remote_ind, mock_get = c("copy", "move",
+  "none"), on_exists = c("replace", "stop"), verbose = FALSE,
   dry_put = getOption("scipiper.dry_put"),
   config_file = getOption("scipiper.s3_config_file"),
   ind_ext = getOption("scipiper.ind_ext"))
@@ -28,7 +28,9 @@ data_file from S3, then the 'a' and 'c' recipes must have
 different targets and this function's local_source argument should match
 the target of the 'a' recipe while this function's remote_ind argument
 should match the target of this recipe (=='b') and the data_file target of
-the 'c' recipe. See the examples.}
+the 'c' recipe. See the examples. Nonetheless, because we have commonly
+adopted the 2-target option where remote_ind and local_source \emph{can} be the
+same, the default for this argument is to set \code{local_source=remote_ind}.}
 
 \item{mock_get}{character. if remote_ind and local_source imply different
 local file locations, should the current local file (implied by


### PR DESCRIPTION
Really tiny PR because I'm sick of having to include two arguments to gd_put or s3_put when in fact one is often plenty. Now you can pass in just one argument, and that argument (`remote_ind`) should be the .ind file, and the corresponding data file you want to push must have exactly the path and data_file name implied by that .ind file.

```r
gd_put('1_fetch/out/mydata.rds.ind')
s3_put('1_fetch/out/mydata.rds.ind')
```

(This is only appropriate if you're both creating and pushing a data file from within the same function, which means a 2-target remake pattern for this shared-cache data file, with one target to create locally + push, one target to retrieve. If you're using a 3-target remake pattern with one target to create locally, one to push, and one to retrieve, you must and can still specify the 2nd argument to gd_put/s3_put so that it points to a data file other than the one indicated by the remote_ind; usually this other data file will be in a /tmp/ directory whereas the remote_ind will point to a similarly named file in the /out/ directory.)