### PR TITLE
Task message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.10
-Date: 2018-07-27
+Version: 0.0.13
+Date: 2018-08-02
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"))
 Description: Functions to organize a data analysis repository and ensure that data flows smoothly.
@@ -15,6 +15,7 @@ Imports:
   storr,
   tidyr,
   whisker,
+  progress,
   yaml
 Suggests:
   googledrive,

--- a/R/loop_tasks.R
+++ b/R/loop_tasks.R
@@ -186,10 +186,12 @@ loop_tasks <- function(
     num_files <- length(file_targets)
     for(i in seq_len(num_files)) {
       target <- file_targets[i]
-      message(sprintf(
-        "Checking file %s of %s: %s",
-        i, num_files, target
-      ))
+      if (verbose){
+        message(sprintf(
+          "Checking file %s of %s: %s",
+          i, num_files, target
+        ))
+      }
       scmake(target, task_makefile, ind_ext=ind_ext, verbose=FALSE)
     }
     msg <- paste(c(

--- a/vignettes/task_plans.Rmd
+++ b/vignettes/task_plans.Rmd
@@ -144,7 +144,7 @@ unlink('build')
 ```{r loop1a}
 loop_tasks(
   task_plan=task_plan_1,
-  task_makefile='task_plan_1.yml', task_mssg = 'progress')
+  task_makefile='task_plan_1.yml')
 ```
 
 The benefits of using `loop_tasks` to run all the remake targets in task_plan_1.yml are:

--- a/vignettes/task_plans.Rmd
+++ b/vignettes/task_plans.Rmd
@@ -144,7 +144,7 @@ unlink('build')
 ```{r loop1a}
 loop_tasks(
   task_plan=task_plan_1,
-  task_makefile='task_plan_1.yml')
+  task_makefile='task_plan_1.yml', task_mssg = 'progress')
 ```
 
 The benefits of using `loop_tasks` to run all the remake targets in task_plan_1.yml are:


### PR DESCRIPTION
This PR has a touch of #65 in it, but is mostly designed to provide an option of much more compact output of `loop_tasks`, which I find to be a really useful function when I am doing a bunch of failure-prone tasks (like fetching data from brittle services/servers). The utility of this is only apparent when you have hundreds/thousands of targets and a decent likelihood of failure. I added the "silent" option, which I'm not sure we should include...since the final `scmake` that is called to verify completeness is not silent (is still `verbose`), but thought it would be a good idea to implement it to have the complete cases covered (verbose, ~compact, and silent). If we want to go all out, we could use that "silent" input to set `verbose` in the final `scmake()` call to `FALSE`. 

But I wanted to get feedback on this PR before messing around with that. 

using `task_msg = 'progress'`:
![task_progress](https://user-images.githubusercontent.com/2349007/43646429-8ab3bdf6-96fa-11e8-8e82-4790387b53be.gif)

using `task_msg = 'verbose'` (the default, and this should not have changed):
![task_verbose](https://user-images.githubusercontent.com/2349007/43646468-a14f3da6-96fa-11e8-88ee-df5723925512.gif)


