### PR TITLE
check for duplicates in gd_locate_file

### DIFF
--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -356,10 +356,13 @@ gd_locate_file <- function(file, config_file=getOption("scipiper.gd_config_file"
     if(nrow(elem_row) == 1) {
       path_exists <- TRUE
       path_df <- bind_rows(path_df, elem_row)
-    } else {
+    } else if(nrow(elem_row) == 0) {
       path_exists <- FALSE
       path_df <- bind_rows(path_df, data_frame(id=NA))
       break
+    } else if(nrow(elem_row) > 0) {
+      stop(sprintf('Found multiple copies of %s in Drive',
+                   do.call(file.path, as.list(path_elements[seq_len(i)]))))
     }
   }
   


### PR DESCRIPTION
Until just now, if there were multiple copies of a file in the same folder, gd_locate_file was just quietly telling us the file didn't exist. This PR should fix that.

To test, I added these folders to a working directory that my gd_config.yml was set up to access:

```
- 6_temp_coop_fetch (dir)
  - test (dir)
  - test (dir)
    - tf1 (file)
    - tf1 (file)
```

Then I looked for the (duplicated) parent and the file itself, and both times got the desired error:
```r
> scipiper:::gd_locate_file("6_temp_coop_fetch/test")
Error in scipiper:::gd_locate_file("6_temp_coop_fetch/test") : 
  Found multiple copies of 6_temp_coop_fetch/test in Drive
> scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1")
Error in scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1") : 
  Found multiple copies of 6_temp_coop_fetch/test in Drive
```
Next I deleted the duplicate test folder and tried again, again got the desired error:
```r
> scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1")
Error in scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1") : 
  Found multiple copies of 6_temp_coop_fetch/test/tf1 in Drive
```
Next I deleted the duplicate tf1 file and got the desired output:
```r
> scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1")
# A tibble: 4 x 4
  name                        id      drive_resource   parents                          
  <chr>                       <chr>           <list>     <chr>                            
1 lake-temperature-model-prep 1BK...     <list [33]>       NA                               
2 6_temp_coop_fetch           1oB...     <list [32]>    1BK...
3 test                        1tO...     <list [31]>    1oB...
4 tf1                         1cd...     <list [31]>    1tO...
```
Then I deleted the remaining tf1 file and got the desired NA result:
```r
> scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1")
# A tibble: 4 x 4

  name                        id      drive_resource   parents                          
  <chr>                       <chr>           <list>     <chr>                            
1 lake-temperature-model-prep 1BK...     <list [33]>       NA                               
2 6_temp_coop_fetch           1oB...     <list [32]>    1BK...
3 test                        1tO...     <list [31]>    1oB...
4 NA                          NA             <NULL>         NA                               
```
And lastly, I deleted the parent test folder and got the desired NA result:
```r
> scipiper:::gd_locate_file("6_temp_coop_fetch/test/tf1")
# A tibble: 3 x 4

  name                        id      drive_resource   parents                          
  <chr>                       <chr>           <list>     <chr>                            
1 lake-temperature-model-prep 1BK...     <list [33]>       NA                               
2 6_temp_coop_fetch           1oB...     <list [32]>    1BK...
3 NA                          NA              <NULL>         NA   
```