### PR TITLE
switch to readr::write_lines for consistent LF line endings

### DIFF
--- a/R/create_task_makefile.R
+++ b/R/create_task_makefile.R
@@ -201,11 +201,13 @@ create_task_makefile <- function(
   # render the template
   yml <- whisker::whisker.render(template, data=params)
   yml <- gsub('[\n]{3,}', '\\\n\\\n', yml) # reduce 3+ line breaks to just 2
+  #yml <- trim(yml) # chop off any trailing white space or line endings (write_lines will add back a final line ending for us)
+  yml <- paste0(substring(yml, 1, nchar(yml)-1), gsub('\\n', '', substring(yml, nchar(yml)))) # chop off the final character if it's a newline
   
   if (is.null(makefile)){
     makefile <- yml
   } else {
-    cat(yml, file=makefile)
+    readr::write_lines(yml, path=makefile)
     if(has_finalize_funs) {
       how_to_run <- paste0(
         "Run all tasks and finalizers with:\n",


### PR DESCRIPTION
`cat` in `create_task_makefile` was writing different line endings depending on whether it was run from a Mac or a Windows machine, so I switched to `readr::write_lines`. (I've done this in other functions in the past; just missed this one.)

Current mismatches between machines will need to be rectified by having the windows users rebuild their task remake files with `scmake(..., force=TRUE)`. My hope+intent is that there will be absolutely no changes to the .yml task files produced by Macs, but we should be vigilant for a while because there might be some. I had to remove a final newline character to get it to stay the same on the file I used to test this PR. I haven't tested on a task makefile that lacks a combiner function, which is the case I think most likely to break. (I actually think it won't break, but it still seems like the weak point).