### PR TITLE
v0.0.17

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.16
-Date: 2018-08-10
+Version: 0.0.17
+Date: 2020-02-03
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),
              person("Jordan", "Read", email = "jread@usgs.gov", role = "ctb"))

--- a/R/create_task_makefile.R
+++ b/R/create_task_makefile.R
@@ -32,6 +32,7 @@
 #'   dummy target name instead, with suffix "_promise". This allows us to avoid cyclic 
 #'   dependencies. Naming convention for `_promise` variables is to drop any dir structure 
 #'   from the `final_targets`
+#' @param tickquote_combinee_objects TRUE by default
 #' @return the file name of the makefile that was created, 
 #'   or the string output (if makefile = NULL)
 #' @export
@@ -69,8 +70,13 @@ create_task_makefile <- function(
   include=c(), packages='scipiper', sources=c(), file_extensions=c('ind'),
   template_file=system.file('extdata/task_makefile.mustache', package='scipiper'),
   final_targets, 
-  finalize_funs = 'combine_to_ind', 
-  as_promises = TRUE) {
+  finalize_funs = 'combine_to_ind',
+  as_promises = TRUE, 
+  tickquote_combinee_objects = TRUE) {
+  
+  if(!missing(tickquote_combinee_objects)) {
+    message('v0.0.17: tickquote_combinee_objects is deprecated and will effectively be always TRUE in future versions')
+  }
   
   # prepare the overall job task: list every step of every job as a dependency.
   # first mutate the makefile file name into an object name to use as the
@@ -130,7 +136,7 @@ create_task_makefile <- function(
     if (('remake' %:::% 'target_is_file')(target, file_extensions = pos_extensions)){
       paste0("'", target, "'")
     } else {
-      target
+      if(tickquote_combinee_objects) paste0("`", target, "`") else target
     }
   })
   

--- a/R/status_info.R
+++ b/R/status_info.R
@@ -170,7 +170,11 @@ get_remake_status <- function(target_names=NULL, remake_file=getOption('scipiper
 #'   nested tibbles for depends and code ('wide'), or a multi-row tibble with
 #'   columns for name, dependency type, and dependency hash ('long')?
 #' @importFrom purrr map2_chr
-get_dependency_status <- function(target_name, remake_object, as_of=c('last_build', 'now'), format=c('raw', 'wide', 'long')) {
+get_dependency_status <- function(
+  target_name,
+  remake_object = ('remake' %:::% 'remake')(remake_file=getOption('scipiper.remake_file'), verbose=FALSE, load_sources=TRUE),
+  as_of=c('last_build', 'now'), format=c('raw', 'wide', 'long')) {
+  
   # process arguments
   target <- remake_object$targets[[target_name]]
   store <- remake_object$store

--- a/man/create_task_makefile.Rd
+++ b/man/create_task_makefile.Rd
@@ -14,7 +14,8 @@ create_task_makefile(
   template_file = system.file("extdata/task_makefile.mustache", package = "scipiper"),
   final_targets,
   finalize_funs = "combine_to_ind",
-  as_promises = TRUE
+  as_promises = TRUE,
+  tickquote_combinee_objects = TRUE
 )
 }
 \arguments{
@@ -51,6 +52,8 @@ final steps from the task plan into depends for the default/all target.}
 dummy target name instead, with suffix "_promise". This allows us to avoid cyclic
 dependencies. Naming convention for \verb{_promise} variables is to drop any dir structure
 from the \code{final_targets}}
+
+\item{tickquote_combinee_objects}{TRUE by default}
 }
 \value{
 the file name of the makefile that was created,

--- a/man/get_dependency_status.Rd
+++ b/man/get_dependency_status.Rd
@@ -6,7 +6,8 @@
 \usage{
 get_dependency_status(
   target_name,
-  remake_object,
+  remake_object = ("remake" \%:::\% "remake")(remake_file =
+    getOption("scipiper.remake_file"), verbose = FALSE, load_sources = TRUE),
   as_of = c("last_build", "now"),
   format = c("raw", "wide", "long")
 )


### PR DESCRIPTION
Two small changes plus a version bump:

1) You can now call `scipiper:::get_dependency_status('targetname')` without writing all the code to get a remake_object. This is still an internal function but has been proving its worth for debugging recently.

2) In task plans, objects with complex names (e.g., 'nhdhr_23094-019867') were giving trouble in the combiner call, where remake failed to parse them. This PR adds tick quotes (\`) around objects in the combiner calls by default. You might want to skip this change for current built task plans, in which case you can specify `tickquote_combinee_objects = FALSE` in the call to `create_task_makefile` so that your task plan stays unchanged. If you do this, you'll get a warning about this argument being deprecated (already, even though this PR introduces it) because in the long run I think we'll be better off with always tickquoting.