### PR TITLE
improve task-step labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.18
-Date: 2020-02-03
+Version: 0.0.19
+Date: 2020-06-02
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),
              person("Jordan", "Read", email = "jread@usgs.gov", role = "ctb"))
@@ -43,5 +43,5 @@ BugReports: https://github.com/USGS-R/scipiper/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr

--- a/R/loop_tasks.R
+++ b/R/loop_tasks.R
@@ -72,8 +72,10 @@ loop_tasks <- function(
   # identify the task-step targets to be run, ordered by tasks and then steps
   # within tasks
   targets <- unlist(lapply(unname(task_plan[task_names]), function(task) {
-    sapply(unname(task$steps[step_names]), `[[`, 'target_name')
+    sapply(task$steps[step_names], `[[`, 'target_name') %>% setNames(., sprintf('%s-%s', task$task_name, names(.)))
   }))
+  target_names <- names(targets)
+  targets <- unname(targets)
   num_targets_overall <- length(targets)
   
   # sometimes, a user knows that something needs to get rebuilt and doesn't want to wait
@@ -164,7 +166,7 @@ loop_tasks <- function(
           # get the names of the target and the task
           target_num_overall <- incomplete_targets[i]
           target <- targets[target_num_overall]
-          task_name <- task_names[target_num_overall]
+          task_name <- target_names[target_num_overall]
           
           # update the progress bar
           if (verbose){


### PR DESCRIPTION
Resolves issue #135 where I couldn't make sense of how loop_tasks's progress messages were matching up with actual applier actions. Now instead of just reporting Building [task], it says "Building [task-step]".

loop_tasks continues to interact awkwardly with messages within applier functions, but for full transparency of actions, here's what I'm seeing in my test case (from ds-pipelines-3-course repo), where the task names are state codes (AL, CT, etc.) and the step names are tally and plot: 
```
### Starting loop attempt 2 of 30 with 9 of 28 tasks remaining:                                                  
  Building AL-tally [========================================================>---------------------------]  68%
  Tallying data for AL-02465000
  Building CT-tally [===========================================================>------------------------]  71%
  Retrieving data for CT-01199000
* Error in get_site_data("1_fetch/tmp/inventory_CT.tsv", parameter): Ugh, the internet data transfer failed! T...
  Building CT-plot [============================================================>------------------------]  71%
  Retrieving data for CT-01199000
* Error in get_site_data("1_fetch/tmp/inventory_CT.tsv", parameter): Ugh, the internet data transfer failed! T...
  Building DE-tally [===========================================================>------------------------]  71%
  Tallying data for DE-01479000
  Building DC-tally [==============================================================>---------------------]  75%
  Retrieving data for DC-01648000
* Error in get_site_data("1_fetch/tmp/inventory_DC.tsv", parameter): Ugh, the internet data transfer failed! T...
  Building DC-plot [===============================================================>---------------------]  75%
  Retrieving data for DC-01648000
Plotting data for DC-01648000
  Building ID-tally [=================================================================>------------------]  79%
  Tallying data for ID-13077000
  Building IL-tally [====================================================================>---------------]  82%
  Tallying data for IL-05572000
  Building IN-tally [=======================================================================>------------]  86%
  Tallying data for IN-03373500
### Starting loop attempt 3 of 30 with 3 of 28 tasks remaining:                                                  
  Building CT-tally [==========================================================================>---------]  89%
  Retrieving data for CT-01199000
Tallying data for CT-01199000
  Building CT-plot [==============================================================================>------]  93%
  Plotting data for CT-01199000
  Building DC-tally [================================================================================>---]  96%
  Tallying data for DC-01648000
All tasks complete [=====================================================================================] 100%  
```

If I take out the within-applier messages, I see the task-step labels overwriting themselves more like a typical progress bar. here are some screenshots:

<img width="949" alt="image" src="https://user-images.githubusercontent.com/12039957/83538521-ea051100-a4c3-11ea-8b44-7ce63d1274e8.png">

<img width="949" alt="image" src="https://user-images.githubusercontent.com/12039957/83538528-ed989800-a4c3-11ea-9c51-da97d4769fe5.png">

<img width="949" alt="image" src="https://user-images.githubusercontent.com/12039957/83538559-f2f5e280-a4c3-11ea-9c4f-9ecc60701358.png">


