### PR TITLE
make fault tolerance more consistent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.19
-Date: 2020-06-02
+Version: 0.0.20
+Date: 2020-06-08
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),
              person("Jordan", "Read", email = "jread@usgs.gov", role = "ctb"))

--- a/tests/testthat/test-loop_tasks.R
+++ b/tests/testthat/test-loop_tasks.R
@@ -80,25 +80,6 @@ test_that("with verbose=FALSE, should see just one progress bar per loop attempt
   cleanup_tasks_demo(dirinfo)
 })
 
-test_that("loop_tasks skips files initially", {
-  dirinfo <- setup_tasks_demo()
-  suppressWarnings(RNGversion("3.5.0")) # R versions >3.5.0 changes set.seed behavior
-  set.seed(100)
-  # if we already have CA.ind, the inital looping phase shouldn't try to build
-  # CA, but if it's out of date, the final looping phase should
-  writeLines('out-of-date file', 'CA.ind')
-  options('scipiper.test_verbose'=TRUE)
-  output <- capture_messages(scmake('models.ind'))
-  start_final_phase <- grep('### Final check', output)
-  initial_phase <- output[seq_len(start_final_phase-1)]
-  final_phase <- output[start_final_phase:length(output)]
-  expect_false(all(grepl('processing CA', initial_phase)))
-  expect_true(any(grepl('processing CA', final_phase)))
-  options('scipiper.test_verbose'=NULL)
-  
-  cleanup_tasks_demo(dirinfo)
-})
-
 test_that("loop_tasks can force rebuild", {
   dirinfo <- setup_tasks_demo()
   


### PR DESCRIPTION
In writing `ds-pipelines-3` I decided we were struggling more with the incomplete fault tolerance for task table rebuilds than with the extra time required for checking many file targets...and that maybe the current code was already doing that check anyway. So I took it out. Now I think any task that remake identifies as not current will get rebuilt during the fault-tolerant loop attempts within a call to `loop_tasks()`.

The original behavior was that if a task-step had a file built already, we wouldn't just assume it was complete until the final (non-fault-tolerant) check for completeness. So if lots of file rebuilds were necessary, they would get built without fault tolerance.

I'm fairly confident this is a good idea but would appreciate a second opinion, @jread-usgs 