### PR TITLE
make getters.yml the sc_retrieve default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.22
-Date: 2020-07-24
+Version: 0.0.23
+Date: 2020-10-11
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),
              person("Jordan", "Read", email = "jread@usgs.gov", role = "ctb"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,5 +43,5 @@ BugReports: https://github.com/USGS-R/scipiper/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/R/01-scipiper.R
+++ b/R/01-scipiper.R
@@ -11,6 +11,7 @@
   op <- options()
   op.scipiper <- list(
     scipiper.remake_file = 'remake.yml',
+    scipiper.getters_file = 'getters.yml',
     scipiper.dry_put = FALSE,
     scipiper.gd_config_file = "lib/cfg/gd_config.yml",
     scipiper.s3_config_file = "lib/cfg/s3_config.yml",

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -402,13 +402,17 @@ combine_to_tibble <- function(...){
 #' @param ind_file the file path of the indicator for which the corresponding
 #'   data_file will be retrieved
 #' @param remake_file the file path+name of the remake file to use in retrieving
-#'   the data file
+#'   the data file. On 10/10/20 the default value was changed from
+#'   `getOption('scipiper.remake_file')` to
+#'   `getOption('scipiper.getters_file')`. It is recommended to place all
+#'   getters in a file named getters.yml or similar, which should not be
+#'   imported by the main remake files.
 #' @param ind_ext the indicator file extension to expect at the end of ind_file,
 #'   and for which any altered targets should have their build/status files
 #'   updated
 #' @return the name of the retrieved data file
 #' @export
-sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.remake_file'), ind_ext=getOption('scipiper.ind_ext')) {
+sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.getters_file'), ind_ext=getOption('scipiper.ind_ext')) {
   data_file <- as_data_file(ind_file, ind_ext=ind_ext)
   scmake(data_file, remake_file=remake_file, ind_ext=ind_ext, verbose=FALSE)
   return(data_file)

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -413,6 +413,9 @@ combine_to_tibble <- function(...){
 #' @return the name of the retrieved data file
 #' @export
 sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.getters_file'), ind_ext=getOption('scipiper.ind_ext'), verbose=FALSE) {
+  if(missing(remake_file) && !file.exists(remake_file)) {
+    warning(sprintf("sc_retrieve now looks for recipes in '%s' (the 'scipiper.getters_file' option) by default, but that file does not exist", getOption('scipiper.getters_file')))
+  }
   data_file <- as_data_file(ind_file, ind_ext=ind_ext)
   scmake(data_file, remake_file=remake_file, ind_ext=ind_ext, verbose=verbose)
   return(data_file)

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -414,7 +414,7 @@ combine_to_tibble <- function(...){
 #' @export
 sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.getters_file'), ind_ext=getOption('scipiper.ind_ext'), verbose=FALSE) {
   if(missing(remake_file) && !file.exists(remake_file)) {
-    warning(sprintf("sc_retrieve now looks for recipes in '%s' (the 'scipiper.getters_file' option) by default, but that file does not exist", getOption('scipiper.getters_file')))
+    warning(sprintf("sc_retrieve now looks for recipes in '%s' (the 'scipiper.getters_file' option) by default, but that file does not exist\n", getOption('scipiper.getters_file')))
   }
   data_file <- as_data_file(ind_file, ind_ext=ind_ext)
   scmake(data_file, remake_file=remake_file, ind_ext=ind_ext, verbose=verbose)

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -412,9 +412,9 @@ combine_to_tibble <- function(...){
 #'   updated
 #' @return the name of the retrieved data file
 #' @export
-sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.getters_file'), ind_ext=getOption('scipiper.ind_ext')) {
+sc_retrieve <- function(ind_file, remake_file=getOption('scipiper.getters_file'), ind_ext=getOption('scipiper.ind_ext'), verbose=FALSE) {
   data_file <- as_data_file(ind_file, ind_ext=ind_ext)
-  scmake(data_file, remake_file=remake_file, ind_ext=ind_ext, verbose=FALSE)
+  scmake(data_file, remake_file=remake_file, ind_ext=ind_ext, verbose=verbose)
   return(data_file)
 }
 

--- a/inst/extdata/tasks_demo/remake.yml
+++ b/inst/extdata/tasks_demo/remake.yml
@@ -13,7 +13,7 @@ packages:
 sources:
   - tasks_demo.R
 
-file_extensions: "ind" # in addition to remake::file_extensions()
+file_extensions: 'ind' # in addition to remake::file_extensions()
 
 target_default: models.ind
 

--- a/inst/extdata/tasks_demo_sc/getters.yml
+++ b/inst/extdata/tasks_demo_sc/getters.yml
@@ -1,0 +1,13 @@
+target_default: my_table.csv
+
+include:
+  - remake.yml
+
+packages:
+  - scipiper
+
+file_extensions: 'ind'
+
+targets:
+  my_table.csv:
+    command: gd_get('my_table.csv.ind')

--- a/inst/extdata/tasks_demo_sc/getters.yml
+++ b/inst/extdata/tasks_demo_sc/getters.yml
@@ -1,8 +1,8 @@
 target_default: none
 
 # bad idea: makes double builds, or at least double checks
-include:
-  - remake.yml
+#include:
+#  - remake.yml
 
 packages:
   - scipiper

--- a/inst/extdata/tasks_demo_sc/getters.yml
+++ b/inst/extdata/tasks_demo_sc/getters.yml
@@ -1,13 +1,25 @@
-target_default: my_table.csv
+target_default: none
 
-include:
-  - remake.yml
+# bad idea: makes double builds, or at least double checks
+#include:
+#  - remake.yml
 
 packages:
   - scipiper
+  
+sources:
+  - process.R
 
-file_extensions: 'ind'
+file_extensions: ind
 
 targets:
-  my_table.csv:
-    command: gd_get('my_table.csv.ind')
+  none:
+    depends:
+
+  # To avoid a remake bug that would cause remake:::remake to read .ind file
+  # dependencies as objects rather than files (even when you have file_extensions: ind),
+  # the ind files should be nested within a directory. We can't just gd_get a file with path
+  # 'my_table.csv.ind', for example.
+
+  out/my_table.csv:
+    command: gd_get('out/my_table.csv.ind')

--- a/inst/extdata/tasks_demo_sc/getters.yml
+++ b/inst/extdata/tasks_demo_sc/getters.yml
@@ -1,8 +1,8 @@
 target_default: none
 
 # bad idea: makes double builds, or at least double checks
-#include:
-#  - remake.yml
+include:
+  - remake.yml
 
 packages:
   - scipiper

--- a/inst/extdata/tasks_demo_sc/process.R
+++ b/inst/extdata/tasks_demo_sc/process.R
@@ -1,0 +1,11 @@
+build_share_table <- function(x, y, out_ind) {
+  tibble(x=x, y=y) %>%
+    readr::write_csv(as_data_file(out_ind))
+  gd_put(out_ind, dry_put=TRUE)
+}
+
+count_table_rows <- function(tbl_ind) {
+  tbl <- sc_retrieve(tbl_ind) %>%
+    readr::read_csv(col_types=cols())
+  return(nrow(tbl))
+}

--- a/inst/extdata/tasks_demo_sc/process.R
+++ b/inst/extdata/tasks_demo_sc/process.R
@@ -6,7 +6,8 @@ build_share_table <- function(x, y, out_ind) {
 }
 
 count_table_rows <- function(tbl_ind) {
-  tbl <- sc_retrieve(tbl_ind, verbose=TRUE) %>%
+  # tbl <- sc_retrieve(tbl_ind, verbose=TRUE) %>%
+  tbl <- sc_retrieve(tbl_ind, 'remake.yml') %>%
     readr::read_csv(col_types=cols())
   return(nrow(tbl))
 }

--- a/inst/extdata/tasks_demo_sc/process.R
+++ b/inst/extdata/tasks_demo_sc/process.R
@@ -1,11 +1,18 @@
 build_share_table <- function(x, y, out_ind) {
+  dir.create(dirname(out_ind), showWarnings = FALSE)
   tibble(x=x, y=y) %>%
     readr::write_csv(as_data_file(out_ind))
   gd_put(out_ind, dry_put=TRUE)
 }
 
 count_table_rows <- function(tbl_ind) {
-  tbl <- sc_retrieve(tbl_ind) %>%
+  tbl <- sc_retrieve(tbl_ind, verbose=TRUE) %>%
     readr::read_csv(col_types=cols())
   return(nrow(tbl))
+}
+
+require_ind_exists <- function(ind) {
+  if(!file.exists(ind)) {
+    stop(sprintf('%s must be built before it can be retrieved', ind))
+  }
 }

--- a/inst/extdata/tasks_demo_sc/process.R
+++ b/inst/extdata/tasks_demo_sc/process.R
@@ -6,8 +6,7 @@ build_share_table <- function(x, y, out_ind) {
 }
 
 count_table_rows <- function(tbl_ind) {
-  # tbl <- sc_retrieve(tbl_ind, verbose=TRUE) %>%
-  tbl <- sc_retrieve(tbl_ind, 'remake.yml') %>%
+  tbl <- sc_retrieve(tbl_ind, verbose=TRUE) %>%
     readr::read_csv(col_types=cols())
   return(nrow(tbl))
 }

--- a/inst/extdata/tasks_demo_sc/remake.yml
+++ b/inst/extdata/tasks_demo_sc/remake.yml
@@ -16,9 +16,6 @@ targets:
   out/my_table.csv.ind:
     command: build_share_table(target_name, x=I(1:5), y=I(c('a','b','c','d','e')))
   
-  out/my_table.csv:
-    command: gd_get('out/my_table.csv.ind')
-  
   nrow_table:
     command: count_table_rows('out/my_table.csv.ind')
 

--- a/inst/extdata/tasks_demo_sc/remake.yml
+++ b/inst/extdata/tasks_demo_sc/remake.yml
@@ -16,6 +16,9 @@ targets:
   out/my_table.csv.ind:
     command: build_share_table(target_name, x=I(1:5), y=I(c('a','b','c','d','e')))
   
+  out/my_table.csv:
+    command: gd_get('out/my_table.csv.ind')
+  
   nrow_table:
     command: count_table_rows('out/my_table.csv.ind')
 

--- a/inst/extdata/tasks_demo_sc/remake.yml
+++ b/inst/extdata/tasks_demo_sc/remake.yml
@@ -13,9 +13,9 @@ file_extensions: 'ind' # in addition to remake::file_extensions()
 
 targets:
 
-  my_table.csv.ind:
+  out/my_table.csv.ind:
     command: build_share_table(target_name, x=I(1:5), y=I(c('a','b','c','d','e')))
   
   nrow_table:
-    command: count_table_rows('my_table.csv.ind')
+    command: count_table_rows('out/my_table.csv.ind')
 

--- a/inst/extdata/tasks_demo_sc/remake.yml
+++ b/inst/extdata/tasks_demo_sc/remake.yml
@@ -1,0 +1,21 @@
+target_default: nrow_table
+
+packages:
+  - dplyr
+  - readr
+  - tibble
+  - scipiper
+
+sources:
+  - process.R
+
+file_extensions: 'ind' # in addition to remake::file_extensions()
+
+targets:
+
+  my_table.csv.ind:
+    command: build_share_table(target_name, x=I(1:5), y=I(c('a','b','c','d','e')))
+  
+  nrow_table:
+    command: count_table_rows('my_table.csv.ind')
+

--- a/man/sc_retrieve.Rd
+++ b/man/sc_retrieve.Rd
@@ -6,7 +6,7 @@
 \usage{
 sc_retrieve(
   ind_file,
-  remake_file = getOption("scipiper.remake_file"),
+  remake_file = getOption("scipiper.getters_file"),
   ind_ext = getOption("scipiper.ind_ext")
 )
 }
@@ -15,7 +15,11 @@ sc_retrieve(
 data_file will be retrieved}
 
 \item{remake_file}{the file path+name of the remake file to use in retrieving
-the data file}
+the data file. On 10/10/20 the default value was changed from
+\code{getOption('scipiper.remake_file')} to
+\code{getOption('scipiper.getters_file')}. It is recommended to place all
+getters in a file named getters.yml or similar, which should not be
+imported by the main remake files.}
 
 \item{ind_ext}{the indicator file extension to expect at the end of ind_file,
 and for which any altered targets should have their build/status files

--- a/man/sc_retrieve.Rd
+++ b/man/sc_retrieve.Rd
@@ -7,7 +7,8 @@
 sc_retrieve(
   ind_file,
   remake_file = getOption("scipiper.getters_file"),
-  ind_ext = getOption("scipiper.ind_ext")
+  ind_ext = getOption("scipiper.ind_ext"),
+  verbose = FALSE
 )
 }
 \arguments{

--- a/tests/testthat/helper-demo.R
+++ b/tests/testthat/helper-demo.R
@@ -1,16 +1,20 @@
 #### task-plan demo ####
 
-setup_tasks_demo <- function() {
+setup_tasks_demo <- function(demo_dir='tasks_demo') {
   
-  find_srcdir <- function() {
-    srcdir <- system.file('inst/extdata/tasks_demo', package='scipiper') # for devtools::test()
-    if(srcdir == '') srcdir <- system.file('extdata/tasks_demo', package='scipiper') # for local tests (and R CMD check?)
+  find_srcdir <- function(demo_dir) {
+    if(basename(normalizePath('.')) == 'scipiper') {
+      srcdir <- file.path('inst/extdata', demo_dir) # for local+fast demo development
+    } else {
+      srcdir <- system.file(file.path('inst/extdata', demo_dir), package='scipiper') # for devtools::test()
+      if(srcdir == '') srcdir <- system.file(file.path('extdata', demo_dir), package='scipiper') # for local tests (and R CMD check?)
+    }    
     return(srcdir)
   }
   
   dirinfo <- list(
     wd = getwd(),
-    srcdir = find_srcdir(),
+    srcdir = find_srcdir(demo_dir),
     tmpdir = tempfile())
   dirinfo$newdir <- file.path(dirinfo$tmpdir, basename(dirinfo$srcdir))
   

--- a/tests/testthat/test-sc_retrieve.R
+++ b/tests/testthat/test-sc_retrieve.R
@@ -1,0 +1,12 @@
+context("Retrieve files from the shared cache")
+
+test_that("sc_retrieve looks to getters.yml by default", {
+  dirinfo <- setup_tasks_demo('tasks_demo_sc')
+  
+  expect_equal(sc_retrieve('my_table.csv.ind'), 'my_table.csv', info="build table via sc_retrieve; assumes getters.yml")
+  expect_true(file.exists('my_table.csv'))
+  expect_equal(scmake('nrow_table'), 5)
+
+  cleanup_tasks_demo(dirinfo)
+})
+

--- a/tests/testthat/test-sc_retrieve.R
+++ b/tests/testthat/test-sc_retrieve.R
@@ -2,11 +2,19 @@ context("Retrieve files from the shared cache")
 
 test_that("sc_retrieve looks to getters.yml by default", {
   dirinfo <- setup_tasks_demo('tasks_demo_sc')
-  
-  expect_equal(sc_retrieve('my_table.csv.ind'), 'my_table.csv', info="build table via sc_retrieve; assumes getters.yml")
-  expect_true(file.exists('my_table.csv'))
+  expect_error(expect_warning(sc_retrieve('out/my_table.csv.ind'), info="expected: can't retrieve files that don't exist"))
+  scmake('out/my_table.csv.ind')
+  expect_true(file.exists('out/my_table.csv.ind'))
+  expect_true(file.exists('out/my_table.csv'))
+  expect_equal(sc_retrieve('out/my_table.csv.ind'), 'out/my_table.csv', info="assumes getters.yml")
   expect_equal(scmake('nrow_table'), 5)
-
+  cleanup_tasks_demo(dirinfo)
+  
+  # Should also be able to build nrow_table directly without double builds
+  dirinfo <- setup_tasks_demo('tasks_demo_sc')
+  build_msgs <- testthat::capture_messages(scmake('nrow_table'))
+  builds_of_ind <- grep('\\] out/my_table.csv.ind[[:space:]]+', build_msgs, value=TRUE)
+  expect_equal(length(builds_of_ind), 1) # should build just once
   cleanup_tasks_demo(dirinfo)
 })
 

--- a/vignettes/shared_cache.Rmd
+++ b/vignettes/shared_cache.Rmd
@@ -88,7 +88,7 @@ gather_and_share_stream_data = function(<ind>ind_file</ind>, state, <data>gd_con
 
 select_sites = function(<ind>ind_file</ind>, <ind>input_ind_file</ind>, <data>gd_config</data>){
 
-  <data>temp</data> = readRDS(sc_retrieve(<ind>input_ind_file</ind>))
+  <data>temp</data> = readRDS(sc_retrieve(<ind>input_ind_file</ind>, 'remake.yml')) # default remake_file is getters.yml as of 10/10/20
   
   <data>temp_sites</data> <- <data>temp</data> %>%
     dplyr::filter(


### PR DESCRIPTION
Resolves #70 by making getters.yml the default remake_file for `sc_retrieve` (but also making that default overridable with `options()`).

I also added tests. Good job to me. And I found and worked around what I believe is another remake bug, which is that if your remake file (e.g., getters.yml) contains .ind files that aren't targets and don't have a file path, remake still reads them as objects even when you have `file_extensions: ind`. How annoying, though at least for most of our pipelines we nest all our .ind files within directories anyway.

The one thing I couldn't do, despite throwing a couple of hours at this, was actually recreate the double-build situation described in #70. I thought I'd be able to do it by including remake.yml within getters.yml, or maybe by packing everything into remake.yml so the example looks a lot like the issue description for #70...but I must be missing something, because I couldn't get two BUILDs of out/my_table.csv.ind no matter what I tried.