### PR TITLE
update readr::write_lines fxn according pkg update in v1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.23
+Version: 0.0.24
 Date: 2020-10-11
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
   dplyr,
   methods,
   purrr,
-  readr,
+  readr (>= 1.4.0),
   remake,
   storr,
   tibble,

--- a/R/create_task_makefile.R
+++ b/R/create_task_makefile.R
@@ -207,7 +207,7 @@ create_task_makefile <- function(
   if (is.null(makefile)){
     makefile <- yml
   } else {
-    readr::write_lines(yml, path=makefile)
+    readr::write_lines(yml, file=makefile)
     if(has_finalize_funs) {
       how_to_run <- paste0(
         "Run all tasks and finalizers with:\n",

--- a/R/scmake.R
+++ b/R/scmake.R
@@ -377,7 +377,7 @@ combine_to_ind <- function(ind_file, ...){
 #' @export
 #' @examples 
 #' tfiles <- tempfile(pattern=as.character(1:3))
-#' for(i in 1:3) readr::write_lines(i, path=tfiles[i])
+#' for(i in 1:3) readr::write_lines(i, file=tfiles[i])
 #' combine_to_tibble(tfiles)
 combine_to_tibble <- function(...){
   if(length(c(...)) < 1) {

--- a/man/combine_to_tibble.Rd
+++ b/man/combine_to_tibble.Rd
@@ -17,6 +17,6 @@ light wrapper on \code{sc_indicate}
 }
 \examples{
 tfiles <- tempfile(pattern=as.character(1:3))
-for(i in 1:3) readr::write_lines(i, path=tfiles[i])
+for(i in 1:3) readr::write_lines(i, file=tfiles[i])
 combine_to_tibble(tfiles)
 }

--- a/tests/testthat/test-combiners.R
+++ b/tests/testthat/test-combiners.R
@@ -2,7 +2,7 @@ context("Combine task targets into summary files or objects")
 
 test_that("combine_to_tibble works on all reasonable numbers of files", {
   tfiles <- tempfile(pattern=as.character(1:3))
-  for(i in 1:3) readr::write_lines(i, path=tfiles[i])
+  for(i in 1:3) readr::write_lines(i, file=tfiles[i])
   expect_s3_class(combine_to_tibble(), 'tbl_df')
   expect_equal(nrow(combine_to_tibble()), 0)
   expect_equal(combine_to_tibble(tfiles[1])$name, tfiles[1])


### PR DESCRIPTION
I started getting this warning when I updated `readr`. This should fix that from happening.

```r
Warning message:
The `path` argument of `write_lines()` is deprecated as of readr 1.4.0.
Please use the `file` argument instead.
```