### PR TITLE
Allow use of EC2 metadata for S3 credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ vignettes/*.R
 vignettes/*.html
 /doc/
 /Meta/
+
+# vim swap files
+.*.swp
+.swp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scipiper
 Title: Support functions for ushering data through a scientific workflow
-Version: 0.0.25
+Version: 0.0.26
 Date: 2020-10-11
 Authors@R: c(person("Alison", "Appling", email = "aappling@usgs.gov", role = c("aut", "cre")),
              person("David", "Watkins", email = "wwatkins@usgs.gov", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,5 +44,5 @@ BugReports: https://github.com/USGS-R/scipiper/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
   progress,
   yaml
 Suggests:
+  aws.ec2metadata,
   aws.s3,
   aws.signature,
   doParallel,

--- a/R/01-scipiper.R
+++ b/R/01-scipiper.R
@@ -15,7 +15,8 @@
     scipiper.dry_put = FALSE,
     scipiper.gd_config_file = "lib/cfg/gd_config.yml",
     scipiper.s3_config_file = "lib/cfg/s3_config.yml",
-    scipiper.ind_ext = 'ind'
+    scipiper.ind_ext = 'ind',
+    scipiper.use_local_aws_credentials = TRUE
   )
   toset <- !(names(op.scipiper) %in% names(op))
   if(any(toset)) options(op.scipiper[toset])

--- a/R/s3.R
+++ b/R/s3.R
@@ -72,7 +72,7 @@ s3_config <- function(bucket, profile='default', config_file=getOption("scipiper
 #'   project-specific configuration information for S3
 #' @param ind_ext the indicator file extension to expect at the end of
 #'   remote_ind
-#' @param use_local_aws_credentials logical If TRUE, calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
+#' @param use_local_aws_credentials If TRUE (the default), then calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
 #'   remote_ind
 #' @export
 s3_put <- function(
@@ -81,7 +81,7 @@ s3_put <- function(
   dry_put=getOption("scipiper.dry_put"),
   config_file=getOption("scipiper.s3_config_file"),
   ind_ext=getOption("scipiper.ind_ext"),
-  use_local_aws_credentials = TRUE) {
+  use_local_aws_credentials = getOption("scipiper.use_local_aws_credentials")) {
   
   # check arguments
   mock_get <- match.arg(mock_get)
@@ -161,12 +161,12 @@ find_local_file <- function(local_source, ind_ext) {
 #' @param config_file character name of the yml file containing project-specific
 #'   configuration information
 #' @param ind_ext the indicator file extension to expect at the end of ind_file
-#' @param use_local_aws_credentials logical If TRUE, calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
+#' @param use_local_aws_credentials If TRUE (the default), then calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
 #' @export
 s3_get <- function(ind_file, verbose = FALSE,
                    config_file=getOption("scipiper.s3_config_file"),
                    ind_ext=getOption("scipiper.ind_ext"),
-                   use_local_aws_credentials = TRUE) {
+                   use_local_aws_credentials = getOption("scipiper.use_local_aws_credentials")) {
   require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   # infer the data file name from the ind_file. gd_get always downloads to that
   # location if it downloads at all

--- a/R/s3.R
+++ b/R/s3.R
@@ -99,7 +99,7 @@ s3_put <- function(
   }
   
   # prepare to use S3
-  require_libs('aws.signature', 'aws.s3')
+  require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   s3_config <- yaml::yaml.load_file(config_file)
   aws.signature::use_credentials(profile = s3_config$profile)
   
@@ -160,7 +160,7 @@ find_local_file <- function(local_source, ind_ext) {
 s3_get <- function(ind_file, verbose = FALSE,
                    config_file=getOption("scipiper.s3_config_file"),
                    ind_ext=getOption("scipiper.ind_ext")) {
-  require_libs('aws.signature', 'aws.s3')
+  require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   # infer the data file name from the ind_file. gd_get always downloads to that
   # location if it downloads at all
   data_file <- as_data_file(ind_file, ind_ext=ind_ext)
@@ -195,7 +195,7 @@ s3_confirm_posted <- function(
   config_file=getOption("scipiper.s3_config_file"),
   ind_ext=getOption("scipiper.ind_ext")) {
   
-  require_libs('aws.signature','aws.s3')
+  require_libs('aws.signature','aws.s3', 'aws.ec2metadata')
   
   # tell R CMD check not to worry about symbols used for dplyr non-standard eval
   Key <- '.dplyr.var'

--- a/R/s3.R
+++ b/R/s3.R
@@ -101,7 +101,7 @@ s3_put <- function(
   # prepare to use S3
   require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   s3_config <- yaml::yaml.load_file(config_file)
-  aws.signature::use_credentials(profile = s3_config$profile)
+  #aws.signature::use_credentials(profile = s3_config$profile)
   
   # determine whether and where the remote file exists
   bucket_contents <- aws.s3::get_bucket_df(bucket = s3_config$bucket,
@@ -177,7 +177,7 @@ s3_get <- function(ind_file, verbose = FALSE,
   if(verbose) {message("Downloading ", data_file, " from S3")}
   
   s3_config <- yaml::yaml.load_file(config_file)
-  aws.signature::use_credentials(profile = s3_config$profile)
+  #aws.signature::use_credentials(profile = s3_config$profile)
   aws.s3::save_object(object = data_file, bucket = s3_config$bucket,
                       file = data_file)
 }

--- a/R/s3.R
+++ b/R/s3.R
@@ -72,13 +72,16 @@ s3_config <- function(bucket, profile='default', config_file=getOption("scipiper
 #'   project-specific configuration information for S3
 #' @param ind_ext the indicator file extension to expect at the end of
 #'   remote_ind
+#' @param use_local_aws_credentials logical If TRUE, calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
+#'   remote_ind
 #' @export
 s3_put <- function(
   remote_ind, local_source=remote_ind,  mock_get=c('copy','move','none'),
   on_exists=c('replace','stop'), verbose = FALSE,
   dry_put=getOption("scipiper.dry_put"),
   config_file=getOption("scipiper.s3_config_file"),
-  ind_ext=getOption("scipiper.ind_ext")) {
+  ind_ext=getOption("scipiper.ind_ext"),
+  use_local_aws_credentials = TRUE) {
   
   # check arguments
   mock_get <- match.arg(mock_get)
@@ -101,7 +104,9 @@ s3_put <- function(
   # prepare to use S3
   require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   s3_config <- yaml::yaml.load_file(config_file)
-  #aws.signature::use_credentials(profile = s3_config$profile)
+  if (use_local_aws_credentials) {
+    aws.signature::use_credentials(profile = s3_config$profile)
+  }
   
   # determine whether and where the remote file exists
   bucket_contents <- aws.s3::get_bucket_df(bucket = s3_config$bucket,
@@ -156,10 +161,12 @@ find_local_file <- function(local_source, ind_ext) {
 #' @param config_file character name of the yml file containing project-specific
 #'   configuration information
 #' @param ind_ext the indicator file extension to expect at the end of ind_file
+#' @param use_local_aws_credentials logical If TRUE, calls to this function will rely on credentials in `~/.aws/credentials`; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
 #' @export
 s3_get <- function(ind_file, verbose = FALSE,
                    config_file=getOption("scipiper.s3_config_file"),
-                   ind_ext=getOption("scipiper.ind_ext")) {
+                   ind_ext=getOption("scipiper.ind_ext"),
+                   use_local_aws_credentials = TRUE) {
   require_libs('aws.signature', 'aws.s3', 'aws.ec2metadata')
   # infer the data file name from the ind_file. gd_get always downloads to that
   # location if it downloads at all
@@ -177,7 +184,9 @@ s3_get <- function(ind_file, verbose = FALSE,
   if(verbose) {message("Downloading ", data_file, " from S3")}
   
   s3_config <- yaml::yaml.load_file(config_file)
-  #aws.signature::use_credentials(profile = s3_config$profile)
+  if (use_local_aws_credentials) {
+    aws.signature::use_credentials(profile = s3_config$profile)
+  }
   aws.s3::save_object(object = data_file, bucket = s3_config$bucket,
                       file = data_file)
 }

--- a/man/create_task_step.Rd
+++ b/man/create_task_step.Rd
@@ -6,11 +6,15 @@
 \usage{
 create_task_step(
   step_name,
-  target_name = function(task_name, step_name, ...) {     sprintf("\%s_\%s", task_name,
-    step_name) },
+  target_name = function(task_name, step_name, ...) {
+     sprintf("\%s_\%s", task_name,
+    step_name)
+ },
   depends = character(0),
-  command = function(task_name, step_name, ...) {     sprintf("\%s(I('\%s'))",
-    step_name, task_name) }
+  command = function(task_name, step_name, ...) {
+     sprintf("\%s(I('\%s'))",
+    step_name, task_name)
+ }
 )
 }
 \arguments{

--- a/man/s3_get.Rd
+++ b/man/s3_get.Rd
@@ -9,7 +9,7 @@ s3_get(
   verbose = FALSE,
   config_file = getOption("scipiper.s3_config_file"),
   ind_ext = getOption("scipiper.ind_ext"),
-  use_local_aws_credentials = TRUE
+  use_local_aws_credentials = getOption("scipiper.use_local_aws_credentials")
 )
 }
 \arguments{
@@ -23,7 +23,7 @@ configuration information}
 
 \item{ind_ext}{the indicator file extension to expect at the end of ind_file}
 
-\item{use_local_aws_credentials}{logical If TRUE, calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.}
+\item{use_local_aws_credentials}{If TRUE (the default), then calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.}
 }
 \description{
 Download a file from S3 to the local project

--- a/man/s3_get.Rd
+++ b/man/s3_get.Rd
@@ -8,7 +8,8 @@ s3_get(
   ind_file,
   verbose = FALSE,
   config_file = getOption("scipiper.s3_config_file"),
-  ind_ext = getOption("scipiper.ind_ext")
+  ind_ext = getOption("scipiper.ind_ext"),
+  use_local_aws_credentials = TRUE
 )
 }
 \arguments{
@@ -21,6 +22,8 @@ downloaded. downloads the S3 object whose key equals the data_file basename}
 configuration information}
 
 \item{ind_ext}{the indicator file extension to expect at the end of ind_file}
+
+\item{use_local_aws_credentials}{logical If TRUE, calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.}
 }
 \description{
 Download a file from S3 to the local project

--- a/man/s3_put.Rd
+++ b/man/s3_put.Rd
@@ -13,7 +13,7 @@ s3_put(
   dry_put = getOption("scipiper.dry_put"),
   config_file = getOption("scipiper.s3_config_file"),
   ind_ext = getOption("scipiper.ind_ext"),
-  use_local_aws_credentials = TRUE
+  use_local_aws_credentials = getOption("scipiper.use_local_aws_credentials")
 )
 }
 \arguments{
@@ -62,7 +62,7 @@ project-specific configuration information for S3}
 \item{ind_ext}{the indicator file extension to expect at the end of
 remote_ind}
 
-\item{use_local_aws_credentials}{logical If TRUE, calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
+\item{use_local_aws_credentials}{If TRUE (the default), then calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
 remote_ind}
 }
 \description{

--- a/man/s3_put.Rd
+++ b/man/s3_put.Rd
@@ -12,7 +12,8 @@ s3_put(
   verbose = FALSE,
   dry_put = getOption("scipiper.dry_put"),
   config_file = getOption("scipiper.s3_config_file"),
-  ind_ext = getOption("scipiper.ind_ext")
+  ind_ext = getOption("scipiper.ind_ext"),
+  use_local_aws_credentials = TRUE
 )
 }
 \arguments{
@@ -59,6 +60,9 @@ anything to Google Drive; they'll just pretend they've done it.}
 project-specific configuration information for S3}
 
 \item{ind_ext}{the indicator file extension to expect at the end of
+remote_ind}
+
+\item{use_local_aws_credentials}{logical If TRUE, calls to this function will rely on credentials in \verb{~/.aws/credentials}; if FALSE, credentials will be gotten from EC2 metadata. Using credentials from EC2 metadata is appropriate when running on EC2 or ECS.
 remote_ind}
 }
 \description{


### PR DESCRIPTION
## Motivation
I'm adapting Vizlab's [gage-conditions-gif](https://github.com/usgs-vizlab/gage-conditions-gif) pipeline to run in an ECS context, so that we can automate the generation of the flow-tiles visualization on a monthly basis. Currently, the code assumes that credentials are stored locally in a `~/.aws/credentials` file.

## Summary of Changes
This adds an option to skip looking for credentials on the local filesystem, and instead pull them from EC2 metadata.
1. The `aws.ec2metadata` package is now suggested for `scipiper` installation, and it is required for running the `s3` functions.
2. The `s3_get()` and `s3_put()` functions now have an argument `use_local_aws_credentials`. If this argument is `FALSE`, then EC2 credentials are used. The default value is `TRUE`, so existing pipelines which use the `s3` functions can run unchanged.

## Validation of Changes
[My fork of gage-conditions-gif](https://github.com/jesse-ross/gage-conditions-gif/tree/awsify) uses this version of `scipiper` (installation is [here](https://github.com/jesse-ross/gage-conditions-gif/blob/awsify/docker/Dockerfile#L44-L46)). It runs correctly on ECS, where I run it with a `.Rprofile` which sets `options(scipiper.use_local_aws_credentials = FALSE)` (here are the [CloudWatch logs](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fgage-conditions-task/log-events/ecs$252Fbuild-stats$252Feab6ed3e14454c918918cbaa4019e548), log in as developer to see). It also runs locally when that `.Rprofile` is not in place or sets `options(scipiper.use_local_aws_credentials = TRUE)`

## Outline of what is/is not expected from the reviewer
I don't have much `scipiper` experience, so any input at all would be welcome!